### PR TITLE
feat!: polling for when the property definition is overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,48 +16,45 @@ or
 
 ## Usage
 
-### Events
+### `waitNostr()`
 
-Four custom events are available on `window` object:
-
-- `beforenostrload`: Fire before `window.nostr` is initialized. Cancellable.
-- `nostrloaded`: Fire after `window.nostr` is initialized.
-- `beforenostrupdate`: Fire before `window.nostr` is updated for the second or subsequent. Cancellable.
-- `nostrupdated`: Fire after `window.nostr` is updated for the second or subsequent.
-
-```js
-window.addEventListener("beforenostrload", (ev) => {
-  console.log(ev.detail.nostr /* NIP-07 interface to be installed */);
-  console.log(window.nostr === undefined /* => true */);
-
-  // You can cancel the installation.
-  ev.preventDefault();
-});
-
-window.addEventListener("nostrloaded", (ev) => {
-  console.log(ev.detail.nostr /* NIP-07 interface installed */);
-  console.log(ev.detail.nostr === window.nostr /* => true */);
-});
-```
-
-### Promise
-
-`readyNostr` is a promise that resolves to NIP-07 interface.
-
-```js
-import { readyNostr } from "nip07-awaiter";
-
-const nostr = await readyNostr;
-```
-
-If you want to set a timeout, you can use `waitNostr` instead.
+Return a promise. It is to be resolved as `window.nostr` when it is installed or as soon as possible thereafter.
+If `window.nostr` is not installed after waiting the given time, it is to be resolved as `undefined`.
 
 ```js
 import { waitNostr } from "nip07-awaiter";
 
+// It will be resolved as `window.nostr` or `undefined` within 1 sec.
 const nostrOrUndefined = await waitNostr(1000);
 ```
 
-### Synchronous interface
+If needed, you can pass a [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). When aborted `waitNostr()` rejects and return the reason.
 
-`getNostr` return synchronously NIP-07 interface if exists.
+```js
+const controller = new AbortController();
+const { signal } = controller;
+
+waitNostr(10 * 1000, { signal });
+```
+
+### `getNostr()`
+
+`getNostr()` return synchronously NIP-07 interface if exists.
+
+```js
+import { getNostr } from "nip07-awaiter";
+
+const pubkey = await getNostr()?.getPublicKey();
+```
+
+### `isNostr()`
+
+`isNostr()` is a type gurad function. Return true if the given value is a NIP-07 extension.
+
+```js
+import { isNostr } from "nip07-awaiter";
+
+if (isNostr(window.nostr)) {
+  console.log(await window.nostr.getPublicKey());
+}
+```

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,74 +1,183 @@
 import type { Nip07 } from "nostr-typedef";
 
-let current: Nip07.Nostr | undefined = undefined;
-const beforenostrload = "beforenostrload";
-const nostrloaded = "nostrloaded";
-const beforenostrupdate = "beforenostrupdate";
-const nostrupdated = "nostrupdated";
-
-let resolveNostr: (nostr: Nip07.Nostr) => void | undefined;
-export const readyNostr = new Promise<Nip07.Nostr>((resolve) => {
-  if ("nostr" in window) {
-    current = window.nostr as Nip07.Nostr;
-    resolve(current);
-  } else {
-    resolveNostr = resolve;
-  }
-});
-
-export const waitNostr = (
-  timeoutMs: number
-): Promise<Nip07.Nostr | undefined> =>
-  Promise.race([
-    new Promise<undefined>((resolve) => {
-      setTimeout(() => {
-        resolve(undefined);
-      }, timeoutMs);
-    }),
-    readyNostr,
-  ]);
-
-export const getNostr = () => window.nostr;
-
-Object.defineProperty(window, "nostr", {
-  configurable: false,
-  get: () => current,
-  set: (nostr) => {
-    const [beforeEvent, afterEvent] = current
-      ? [beforenostrupdate, nostrupdated]
-      : [beforenostrload, nostrloaded];
-
-    const goOn = window.dispatchEvent(
-      new CustomEvent(beforeEvent, {
-        cancelable: true,
-        detail: { nostr },
-      })
-    );
-
-    if (goOn) {
-      current = nostr;
-
-      window.dispatchEvent(
-        new CustomEvent(afterEvent, {
-          cancelable: false,
-          detail: { nostr },
-        })
-      );
-      if (afterEvent === nostrloaded) {
-        resolveNostr?.(nostr);
-      }
-    }
-  },
-});
-
 declare global {
-  interface WindowEventMap {
-    [beforenostrload]: CustomEvent<{ nostr: Nip07.Nostr }>;
-    [nostrloaded]: CustomEvent<{ nostr: Nip07.Nostr }>;
-    [beforenostrupdate]: CustomEvent<{ nostr: Nip07.Nostr }>;
-    [nostrupdated]: CustomEvent<{ nostr: Nip07.Nostr }>;
-  }
-
   // eslint-disable-next-line no-var
   var nostr: Nip07.Nostr | undefined;
+}
+
+export type MaybeNip07Extension = Nip07.Nostr | undefined;
+
+export interface AbortableOption {
+  signal?: AbortSignal;
+}
+
+export const getNostr = () =>
+  isNostr(window.nostr) ? window.nostr : undefined;
+
+export async function waitNostr(
+  timeoutMs: number,
+  options?: AbortableOption
+): Promise<MaybeNip07Extension> {
+  if (isNostr(window.nostr)) {
+    return window.nostr;
+  }
+
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  const rejectWhenAborted = new Promise<never>((_, reject) => {
+    options?.signal?.addEventListener("abort", () => {
+      controller.abort(options.signal?.reason);
+
+      try {
+        options?.signal?.throwIfAborted();
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      reject(new Error("aborted unexpectedly"));
+    });
+  });
+
+  const promises: Promise<MaybeNip07Extension>[] = [
+    rejectWhenAborted,
+    // This is not the quickest, but a solid method.
+    startPolling({ signal }),
+  ];
+
+  if (
+    typeof timeoutMs === "number" &&
+    Number.isFinite(timeoutMs) &&
+    timeoutMs > 0
+  ) {
+    promises.push(timeout({ signal, timeoutMs }));
+  }
+
+  // If this method works, this is the quickest way to resolve the promise.
+  // But in some case, it doesn't work.
+  //   (c.f. https://github.com/penpenpng/nip07-awaiter/issues/1)
+  if (canSetupSetterHook()) {
+    promises.push(setupSetterHook());
+  }
+
+  return Promise.race(promises).then((result) => {
+    controller.abort("teardown");
+
+    return result;
+  });
+}
+
+function startPolling(options: AbortableOption): Promise<MaybeNip07Extension> {
+  return new Promise<MaybeNip07Extension>((resolve) => {
+    const clearInterval = setHeuristicInterval(() => {
+      const nostr = getNostr();
+
+      if (nostr) {
+        resolve(nostr);
+        clearInterval();
+      }
+    });
+
+    options.signal?.addEventListener("abort", clearInterval);
+  });
+}
+
+function timeout(
+  params: AbortableOption & { timeoutMs: number }
+): Promise<undefined> {
+  return new Promise<undefined>((resolve) => {
+    const timer = setTimeout(() => {
+      resolve(undefined);
+    }, params.timeoutMs);
+
+    params.signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+    });
+  });
+}
+
+function canSetupSetterHook(): boolean {
+  const descriptor = Object.getOwnPropertyDescriptor(window, "nostr");
+
+  if (!descriptor) {
+    return true;
+  }
+
+  return descriptor.configurable ?? false;
+}
+
+function setupSetterHook(): Promise<MaybeNip07Extension> {
+  let current: MaybeNip07Extension = window.nostr;
+
+  return new Promise<MaybeNip07Extension>((resolve) => {
+    Object.defineProperty(window, "nostr", {
+      configurable: true,
+      get: () => current,
+      set: (nostr) => {
+        if (isNostr(nostr)) {
+          resolve(nostr);
+        }
+
+        current = nostr;
+      },
+    });
+  });
+}
+
+function setHeuristicInterval(callback: () => void) {
+  let timeSum = 0;
+  let time = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const updateInterval = () => {
+    timeSum += time;
+    if (timeSum < 1000) {
+      time = 10;
+    } else if (timeSum < 5000) {
+      time = 100;
+    } else {
+      time = 1000;
+    }
+  };
+
+  const spawn = () => {
+    updateInterval();
+
+    timer = setTimeout(() => {
+      callback();
+      spawn();
+    }, time);
+  };
+
+  const teardown = () => {
+    clearTimeout(timer);
+  };
+
+  spawn();
+
+  return teardown;
+}
+
+export function isNostr(value: unknown): value is Nip07.Nostr {
+  if (!value) {
+    return false;
+  }
+
+  const maybeNostr = value as Nip07.Nostr;
+
+  try {
+    const hasGetPublicKey =
+      "getPublicKey" in maybeNostr &&
+      (typeof maybeNostr.getPublicKey === "function" ||
+        typeof maybeNostr.getPublicKey === "object");
+    const hasSignEvent =
+      "signEvent" in maybeNostr &&
+      (typeof maybeNostr.signEvent === "function" ||
+        typeof maybeNostr.signEvent === "object");
+
+    return hasGetPublicKey && hasSignEvent;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
resolve #1.

Because of the reason as explained in #1, some APIs no longer are provided:

- Event based API.
- `readyNostr`